### PR TITLE
fixes pod validation failure due to missing homepage attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "author": "Vitor Pamplona <vitor@vitorpamplona.com> based on Will Dimmit's design on GitHub",
     "license": "MIT",
     "repository": "https://github.com/vitorpamplona/react-native-ble-advertiser",
+    "homepage": "https://github.com/vitorpamplona/react-native-ble-advertiser",
     "bugs": "https://github.com/vitorpamplona/react-native-ble-advertiser/issues",
     "peerDependencies": {
         "react-native": ">=0.50"


### PR DESCRIPTION
thanks for making this! this just fixes the below error when trying to install pods

```[!] The `react-native-ble-advertiser` pod failed to validate due to 1 error:
    - ERROR | attributes: Missing required attribute `homepage`.```

