### PR TITLE
 use npm ci before building the project

### DIFF
--- a/repack.sh
+++ b/repack.sh
@@ -1,4 +1,5 @@
 #! /bin/sh 
+npm ci
 
 PACKAGE_VERSION=$(cat package.json \
   | grep version \


### PR DESCRIPTION
use npm ci before building the project or we are going to have build issues we executing pod install